### PR TITLE
refactor: Recreate Homebrew symlinks in pkg build with tests

### DIFF
--- a/brew-pkg.rb
+++ b/brew-pkg.rb
@@ -82,6 +82,40 @@ module Homebrew extend self
     end
   end
 
+  def recreate_homebrew_links(staging_root, formula_name, version)
+    cellar_formula_path = File.join(staging_root, 'Cellar', formula_name, version)
+    
+    return unless File.directory?(cellar_formula_path)
+
+    link_dirs = %w[bin lib include share etc sbin]
+    
+    link_dirs.each do |dir|
+      source_dir = File.join(cellar_formula_path, dir)
+      next unless File.directory?(source_dir)
+      
+      target_base = File.join(staging_root, dir)
+      
+      Dir.glob(File.join(source_dir, '**', '*'), File::FNM_DOTMATCH).each do |source|
+        next if ['.', '..'].include?(File.basename(source))
+        
+        relative = Pathname.new(source).relative_path_from(Pathname.new(cellar_formula_path))
+        target = File.join(staging_root, relative.to_s)
+        
+        if File.directory?(source) && !File.symlink?(source)
+          FileUtils.mkdir_p(target)
+        else
+          target_dir = File.dirname(target)
+          FileUtils.mkdir_p(target_dir)
+          
+          next if File.exist?(target) || File.symlink?(target)
+          
+          rel_link = Pathname.new(source).relative_path_from(Pathname.new(target_dir))
+          FileUtils.ln_sf(rel_link.to_s, target)
+        end
+      end
+    end
+  end
+
   def pkg
     options = {
       identifier_prefix: 'org.homebrew',
@@ -138,10 +172,10 @@ the conventions of OS X installer packages.
       ownership_options = ['recommended', 'preserve', 'preserve-other']
       opts.on('-w', '--ownership ownership_mode', 'Define the ownership as: recommended, preserve or preserve-other') do |o|
         if ownership_options.include?(o)
-          options[:ownership] = value
-          puts "Setting pkgbuild option --ownership with value #{value}"
+          options[:ownership] = o
+          puts "Setting pkgbuild option --ownership with value #{o}"
         else
-          opoo "#{value} is not a valid value for pkgbuild --ownership option, ignoring"
+          opoo "#{o} is not a valid value for pkgbuild --ownership option, ignoring"
         end
       end
 
@@ -226,12 +260,15 @@ the conventions of OS X installer packages.
 
         dirs.each { |d| safe_system "rsync", "-a", "#{d}", "#{staging_root}/" }
 
-        if File.exist?("#{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}") && !options[:without_deps]
+        if File.exist?("#{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}") && !options[:without_kegs]
           puts "Staging directory #{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}"
           safe_system "mkdir", "-p", "#{staging_root}/Cellar/#{formula.name}/"
           safe_system "rsync", "-a", "#{HOMEBREW_CELLAR}/#{formula.name}/#{dep_version}", "#{staging_root}/Cellar/#{formula.name}/"
           safe_system "mkdir", "-p", "#{staging_root}/opt"
           safe_system "ln", "-s", "../Cellar/#{formula.name}/#{dep_version}", "#{staging_root}/opt/#{formula.name}"
+          
+          puts "Recreating Homebrew symlinks for #{formula.name}"
+          recreate_homebrew_links(staging_root, formula.name, dep_version)
         end
       end
 

--- a/test.sh
+++ b/test.sh
@@ -1,33 +1,87 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
-# Install latest brew
 if [[ $(command -v brew) == "" ]]; then
     echo "Installing brew in order to build MetaCall"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
-# Install brew-pkg
 brew tap --verbose metacall/brew-pkg
 brew install --verbose --HEAD metacall/brew-pkg/brew-pkg
 
-# Test Python with dependencies, compress and custom output tarball name
 brew install python@3.12
 brew pkg --name python --with-deps --compress python@3.12
 test -f python.tar.gz
 test -f python.pkg
-# tar -ztvf python.tar.gz
 
 brew pkg --name python-without-deps --compress python@3.12
 test -f python-without-deps.tar.gz
 test -f python-without-deps.pkg
-# tar -ztvf python-without-deps.tar.gz
 
 brew install ruby@3.3
 brew pkg --name ruby-with-python --compress --relocatable --additional-deps python@3.12 ruby@3.3
 test -f ruby-with-python.tar.gz
 test -f ruby-with-python.pkg
-# tar -ztvf ruby-with-python.tar.gz
 
-# Debug files and sizes
-ls -lh
+ls -lh python.tar.gz python.pkg python-without-deps.tar.gz python-without-deps.pkg ruby-with-python.tar.gz ruby-with-python.pkg
+
+verify_symlinks() {
+    local tarball=$1
+    local extract_dir="/tmp/verify_$$"
+    
+    echo "Verifying symlinks in $tarball..."
+    
+    rm -rf "$extract_dir"
+    mkdir -p "$extract_dir"
+    tar -xzf "$tarball" -C "$extract_dir"
+    
+    local symlink_count=0
+    local broken_count=0
+    local absolute_count=0
+    
+    while IFS= read -r -d '' link; do
+        symlink_count=$((symlink_count + 1))
+        local target
+        target=$(readlink "$link")
+        
+        if [[ "$target" == /* ]]; then
+            echo "ERROR: Absolute symlink found: $link -> $target"
+            absolute_count=$((absolute_count + 1))
+        fi
+        
+        local link_dir
+        link_dir=$(dirname "$link")
+        local resolved="${link_dir}/${target}"
+        
+        if [[ ! -e "$resolved" ]]; then
+            echo "ERROR: Broken symlink: $link -> $target"
+            broken_count=$((broken_count + 1))
+        fi
+    done < <(find "$extract_dir" -type l -print0)
+    
+    rm -rf "$extract_dir"
+    
+    if [[ $absolute_count -gt 0 ]]; then
+        echo "FAIL: Found $absolute_count absolute symlinks in $tarball"
+        return 1
+    fi
+    
+    if [[ $broken_count -gt 0 ]]; then
+        echo "FAIL: Found $broken_count broken symlinks in $tarball"
+        return 1
+    fi
+    
+    if [[ $symlink_count -eq 0 ]]; then
+        echo "FAIL: No symlinks found in $tarball"
+        return 1
+    fi
+    
+    echo "PASS: $tarball has $symlink_count valid relative symlinks"
+    return 0
+}
+
+verify_symlinks python.tar.gz
+verify_symlinks python-without-deps.tar.gz
+verify_symlinks ruby-with-python.tar.gz
+
+echo "All symlink verification tests passed"

--- a/test.sh
+++ b/test.sh
@@ -1,30 +1,39 @@
 #!/usr/bin/env bash
 set -euxo pipefail
 
+# Install latest brew
 if [[ $(command -v brew) == "" ]]; then
     echo "Installing brew in order to build MetaCall"
     /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 fi
 
+# Install brew-pkg
 brew tap --verbose metacall/brew-pkg
 brew install --verbose --HEAD metacall/brew-pkg/brew-pkg
 
+# Test Python with dependencies, compress and custom output tarball name
 brew install python@3.12
 brew pkg --name python --with-deps --compress python@3.12
 test -f python.tar.gz
 test -f python.pkg
+tar -ztvf python.tar.gz
 
+# Test Python without dependencies, compress and custom output tarball name
 brew pkg --name python-without-deps --compress python@3.12
 test -f python-without-deps.tar.gz
 test -f python-without-deps.pkg
+tar -ztvf python-without-deps.tar.gz
 
+# Test Ruby with additional dependencies, compress and custom output tarball name
 brew install ruby@3.3
 brew pkg --name ruby-with-python --compress --relocatable --additional-deps python@3.12 ruby@3.3
 test -f ruby-with-python.tar.gz
 test -f ruby-with-python.pkg
+tar -ztvf ruby-with-python.tar.gz
 
 ls -lh python.tar.gz python.pkg python-without-deps.tar.gz python-without-deps.pkg ruby-with-python.tar.gz ruby-with-python.pkg
 
+# Symlink tests
 verify_symlinks() {
     local tarball=$1
     local extract_dir="/tmp/verify_$$"


### PR DESCRIPTION
Introduce a new helper function, `recreate_homebrew_links`, to handle the creation of relative symlinks within the staging directory during the package building process. This ensures that dependencies and installed files are correctly linked when the package is installed.

Also, update the test script to include a verification step for these symlinks, ensuring they are relative and not broken. This provides greater confidence in the integrity of the generated packages.

credit: #5 